### PR TITLE
[FIX]Fix apc cache typo

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -151,7 +151,7 @@ return [
     | Configure meta-data, query and result caching here.
     | Optionally you can enable second level caching.
     |
-    | Available: acp|array|file|memcached|redis|void
+    | Available: apc|array|file|memcached|redis|void
     |
     */
     'cache'                     => [


### PR DESCRIPTION
### Changes proposed in this pull request:
- Fix `acp` typo in config template
